### PR TITLE
fixes wordle storage compute with cache

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,14 +5,14 @@ from pyparsing import line
 from wordle import is_wordle_share, find_try_ratio, WordleHistoryState
 config = dotenv_values(".env")
 
+WORDLE_DAILY_CHANNEL = 937390252576886845
+MAIN_CHANNEL = 731718737694162977
 
 class WordleClient(discord.Client):
 
     async def __channel_import__(self, id: str):
-        print(id)
         channel = self.get_channel(id)
         messages = await channel.history(limit=1000).flatten()
-        print('messages len', len(messages))
         self.leaderboards[id] = WordleHistoryState()
         for message in messages:
             message_content = message.content.strip()
@@ -29,42 +29,69 @@ class WordleClient(discord.Client):
                                                  won_on_try_num=won_on_try,
                                                  total_num_tries=max_tries,
                                                  created_date=message.created_at)
-        print(self.leaderboards[id])
+        # special logic for my server -
+        # if this is the wordle channel, let's also import main channel wordle games for same leaderboard
+        if id == WORDLE_DAILY_CHANNEL:
+            # import main
+            channel = self.get_channel(MAIN_CHANNEL)
+            messages = await channel.history(limit=1000).flatten()
+            for message in messages:
+                message_content = message.content.strip()
+                if message.author.bot is True:
+                    continue
+
+                if is_wordle_share(message_content):
+                    lines = message_content.split('\n')
+                    wordle_id = int(str(lines[0][7:10]))
+                    won_on_try, max_tries = find_try_ratio(lines[0])  # param is header of share
+                    self.leaderboards[WORDLE_DAILY_CHANNEL].add_wordle(player_id=message.author.display_name,
+                                                                       wordle_id=wordle_id,
+                                                                       won_on_try_num=won_on_try,
+                                                                       total_num_tries=max_tries,
+                                                                       created_date=message.created_at)
 
     def __make_leaderboard_embed__(self, title: str, df: pandas.DataFrame):
-
         embed = discord.Embed(title=f"__**{title}:**__", color=0x03f8fc)
         for index, row in df.iterrows():
-            print(index, row)
             embed.add_field(name=f'**{index + 1}) {row.player_id}**',
-                            value=f'Total Games: {row.total_games}\n> Averaging: {row.avg_won_on_attempt}/6 \n> Win %: {row.win_percent}\n> Started: {row.started_date}', inline=False)
+                            value=f'Total Games: {row.total_games}\n> Averaging: {row.avg_won_on_attempt}/6 \n> Win %: {row.win_percent}\n> Started: {row.started_date}', 
+                            inline=False)
         return embed
 
     async def on_ready(self):
         print('We have logged in as {0.user}'.format(client))
-        self.leaderboards = dict()  # <channel_id: WordleHistoryState>
+        self.leaderboards = dict()  # <channel_id str: WordleHistoryState>
 
     async def on_message(self, message):
+        if message.author.bot:
+            return
 
-        if message.content == '$shutdown':  # and message.author.display_name == 'Goose':
+        if message.content == '$shutdown':
             exit(0)
 
         if message.content == '$leaderboard':
-            # channel_for_leaderboard = message.channel.id
-            channel_for_leaderboard = 937390252576886845
+            channel_for_leaderboard = message.channel.id
+            # channel_for_leaderboard = WORDLE_DAILY_CHANNEL
             if channel_for_leaderboard not in self.leaderboards:
                 await self.__channel_import__(channel_for_leaderboard)
-            all_stats_df = self.leaderboards.get(channel_for_leaderboard).create_all_stats_df()
-            embed = self.__make_leaderboard_embed__("Leaderboard", all_stats_df)
+            all_stats_df = self.leaderboards.get(
+                channel_for_leaderboard).create_all_stats_df()
+            embed = self.__make_leaderboard_embed__(
+                "Leaderboard", all_stats_df)
             await message.channel.send(embed=embed)
             return
 
         if message.content.startswith('$hello'):
             await message.channel.send('Hello!\n v0.0.1 \nBetter Worlde Bot says hello!!')
+        
+        if message.content.startswith('$help'):
+            await message.channel.send('If this is an emergency, please dial 911. \nSupported commands: `$leaderboard`')
 
-        # store new wordles so we don't need to import again
-        if message.author.bot is False and is_wordle_share(message.content.strip()):
-            lines = message.content.strip().split('\n')
+        # store new wordles so we don't need to import again 
+        # TODO: Not working...
+        if is_wordle_share(message.content.strip()):
+            message_content = message.content.strip()
+            lines = message_content.split('\n')
             wordle_id = int(str(lines[0][7:10]))
             won_on_try, max_tries = find_try_ratio(
                 lines[0])  # just give header
@@ -73,6 +100,7 @@ class WordleClient(discord.Client):
                                                 won_on_try_num=won_on_try,
                                                 total_num_tries=max_tries,
                                                 created_date=message.created_at)
+
 
 client = WordleClient()
 client.run(config["BOT_TOKEN"])


### PR DESCRIPTION
TODO
- Adding a new wordle does not provide the same behavior as a full import. If the bot is started and a new wordle is posted, it is not computed in the leaderboard. 